### PR TITLE
withMotion: Handle animation on initial mount/render

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ function fadeInAndMoveUp({animate}) {
   return animate({
     opacity: [0, 1],
     translateY: [-20, 0],
-  })
+  }).finished
 }
 
 function fadeOut({animate}) {
@@ -63,7 +63,7 @@ function fadeOut({animate}) {
     opacity: [0, 1],
     duration: 500,
     easing: 'linear',
-  })
+  }).finished
 }
 ```
 

--- a/docs/Motion.md
+++ b/docs/Motion.md
@@ -29,7 +29,7 @@ function fadeInAndMoveUp({animate}) {
   return animate({
     opacity: [0, 1],
     translateY: [-20, 0],
-  })
+  }).finished
 }
 
 function fadeOut({animate}) {
@@ -37,7 +37,7 @@ function fadeOut({animate}) {
     opacity: [0, 1],
     duration: 500,
     easing: 'linear',
-  })
+  }).finished
 }
 ```
 
@@ -45,8 +45,8 @@ function fadeOut({animate}) {
 
 ### `componentDidMount({ node, animate, props })`
 
-* **Type** `Function<Promise>` 
-* **Default** `() => Promise.resolve()`
+- **Type** `Function<Promise>`
+- **Default** `() => Promise.resolve()`
 
 Promise that runs when the component is mounted.
 
@@ -62,8 +62,8 @@ Promise that runs when the component is mounted.
 
 ### `componentWillUnmount({ node, animate, props })`
 
-* **Type** `Function<Promise>`
-* **Default** `() => Promise.resolve()`
+- **Type** `Function<Promise>`
+- **Default** `() => Promise.resolve()`
 
 Promise that runs when the component is unmounted.
 

--- a/docs/withMotion.md
+++ b/docs/withMotion.md
@@ -28,7 +28,7 @@ function fadeInAndMoveUp({animate}) {
   return animate({
     opacity: [0, 1],
     translateY: [-20, 0],
-  })
+  }).finished
 }
 
 function moveLeftRight({animate}) {
@@ -44,7 +44,7 @@ function moveLeftRight({animate}) {
         translateX: 0,
       },
     ],
-  })
+  }).finished
 }
 
 function fadeOut({animate}) {
@@ -52,7 +52,7 @@ function fadeOut({animate}) {
     opacity: [0, 1],
     duration: 500,
     easing: 'linear',
-  })
+  }).finished
 }
 ```
 
@@ -65,6 +65,7 @@ function fadeOut({animate}) {
   componentDidMount: () => Promise.resolve(),
   componentDidUpdate: () => Promise.resolve(),
   componentWillUnmount: () => Promise.resolve(),
+  isAnimateOnInitialMount: true,
   pure: true,
 }
 ```
@@ -118,6 +119,13 @@ Promise that runs when the component is unmounted.
 | node    | `HTMLElement` | The target DOM element.               |
 | animate | `Function`    | The [animate](./animate.md) function. |
 | props   | `Object`      | Props passed to `<Motion />`.         |
+
+### `isAnimateOnInitialMount`
+
+- **Type** `boolean`
+- **Default** `true`
+
+Determines if the component can animate on the initial mount/render.
 
 ### `pure`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8256,7 +8256,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8277,12 +8278,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8297,17 +8300,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8424,7 +8430,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8436,6 +8443,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8450,6 +8458,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8457,12 +8466,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8481,6 +8492,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8561,7 +8573,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8573,6 +8586,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8658,7 +8672,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8694,6 +8709,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8713,6 +8729,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8756,12 +8773,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -13822,6 +13841,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -14154,7 +14174,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -14267,6 +14288,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -14304,7 +14326,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -14505,7 +14528,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/stories/Inbox.stories.js
+++ b/stories/Inbox.stories.js
@@ -120,6 +120,7 @@ const Excerpt = styled('div')`
 `
 
 const AnimatedListItem = withMotion({
+  isAnimateOnInitialMount: false,
   componentDidMount: ({node, animate}) => {
     animate({
       keyframes: [


### PR DESCRIPTION
## withMotion: Handle animation on initial mount/render

![Screen Recording 2019-05-23 at 11 31 AM](https://user-images.githubusercontent.com/2322354/58266230-4715a500-7d4f-11e9-8667-4c825d5e0b4f.gif)
(GIF: Shows item components not animating on initial load. But they do animate when (re)added)

This update adds a new prop/option to `withMotion` that can control the
animation rendering for a component. This prop is called
`isAnimateOnInitialMount`.

By default, it is set to `true`, which does not affect the animations for
current implementations.

If set to `false`, the component will only fire it's `componentDidMount`
animations after the initial page render.